### PR TITLE
DEV-592: Handle API errors in feedback form

### DIFF
--- a/src/lib/FeedbackForm.svelte
+++ b/src/lib/FeedbackForm.svelte
@@ -58,7 +58,7 @@
   }
 
   // handles front-end reaction to form submission
-  const onSubmit = async () => {
+  const onSubmit = () => {
       // set the submit button spinner spinning
       loading = true;
 

--- a/src/lib/FeedbackForm.svelte
+++ b/src/lib/FeedbackForm.svelte
@@ -29,8 +29,6 @@
   // when true, shows the success/failure alert message
   let submitted = false;
   
-  // TODO
-  // add try/catch to fetch
   const onSubmit = async () => {
     loading = true;
     //shoelace serializer for turning FormData into JSON
@@ -38,27 +36,27 @@
     const data = serialize(form)
 
     try {
-    const res = await fetch('http://localhost:5000/api', {
-          method: 'POST', 
-            body: JSON.stringify(data),
-            headers: {
-                'Content-Type': 'application/json',
-                'Accept': 'application/json'
-            }
-        })
+      const res = await fetch('http://localhost:5000/api', {
+            method: 'POST', 
+              body: JSON.stringify(data),
+              headers: {
+                  'Content-Type': 'application/json',
+                  'Accept': 'application/json'
+              }
+          })
 
-    const json = await res.json()
-    postResponseStatusCode = res.status;
-    loading = false;
-    submitted = true;
+      const json = await res.json()
+      postResponseStatusCode = res.status;
+      loading = false;
+      submitted = true;
 
-    if (res.ok) {
-      hidden = true;
-      console.log(`request created in service desk ${json.serviceDeskId}: ${json.issueKey}`)
-      console.log('status code', postResponseStatusCode)
-    } else {
-      throw new Error(`There was an error posting the form: ${res.status}, ${res.statusText}`)
-    }
+      if (res.ok) {
+        hidden = true;
+        console.log(`request created in service desk ${json.serviceDeskId}: ${json.issueKey}`)
+        console.log('status code', postResponseStatusCode)
+      } else {
+        throw new Error(`There was an error posting the form: ${res.status}, ${res.statusText}`)
+      }
     } catch(error) {
       loading = false;
       submitted = true;

--- a/src/lib/FeedbackForm.svelte
+++ b/src/lib/FeedbackForm.svelte
@@ -1,14 +1,27 @@
 <script lang="ts">
 
+  import FormMessage from './FormMessage.svelte';
+  import { slide } from 'svelte/transition';
   import '@shoelace-style/shoelace/dist/components/button/button.js';
   import '@shoelace-style/shoelace/dist/components/input/input.js';
   import '@shoelace-style/shoelace/dist/components/textarea/textarea.js';
   import { serialize } from '@shoelace-style/shoelace/dist/utilities/form.js'
+  import '@shoelace-style/shoelace/dist/components/alert/alert.js';
    
   let userURL: string = location.href;
   let userAgent: string = navigator.userAgent;
+
+  let postResponseStatusCode;
+
+  let loading = false;
   
+  // const isUserLoggedIn = async () => {
+  //   const res = await fetch('/cgi/ping');
+  //   const broken = res.json()
+  //   console.log(broken)
+  // }
   const onSubmit = async () => {
+    loading = true;
     //shoelace serializer for turning FormData into JSON
     const form = document.querySelector('form')
     const data = serialize(form)
@@ -23,10 +36,16 @@
         })
 
         const json = await res.json()
-        console.log(JSON.stringify(json))
+        postResponseStatusCode = res.status;
+        loading = false;
+        console.log(`request created in service desk ${json.serviceDeskId}: ${json.issueKey}`)
+        console.log('status code', postResponseStatusCode)
     }
 </script>
 
+
+
+<!-- <form on:submit|preventDefault={onSubmit}> -->
 <form on:submit|preventDefault={onSubmit}>
    
       <sl-input class="label-on-left" label="Name" name="name" id="name" type="name" ></sl-input>
@@ -44,9 +63,30 @@
     
       <div class="form-options">
       <sl-button class="btn form-button" variant="default" type="submit" value="Submit" aria-label="Submit">Cancel</sl-button>
-      <sl-button class="btn form-button" variant="primary" type="submit" value="Submit" aria-label="Submit">Submit</sl-button>
+      <sl-button class="btn form-button" variant="primary" type="submit" value="Submit" aria-label="Submit" {loading}>Submit</sl-button>
       </div>
-   
+
+      
+      <!-- <FormMessage /> -->
+      <section>
+        {#if postResponseStatusCode === 200}
+        <div transition:slide>
+          <sl-alert variant="success" open>
+            <sl-icon slot="icon" name="check2-circle"></sl-icon>
+            <strong>Thank you!</strong><br />
+            Your feedback has been submitted.
+          </sl-alert> 
+        </div>
+        {:else if postResponseStatusCode === 500}
+        <div transition:slide>
+          <sl-alert variant="danger" open>
+            <sl-icon slot="icon" name="exclamation-octagon"></sl-icon>
+            <strong>Oops!</strong><br />
+            There was an error submitting the form. Please try again or email us at support@hathitrust.org
+          </sl-alert> 
+        </div>
+        {/if}
+      </section>
   </form>
 
   <style>

--- a/src/lib/FeedbackForm.svelte
+++ b/src/lib/FeedbackForm.svelte
@@ -13,28 +13,28 @@
 
   //takes long string output of document.cookie and splits it into a usable javascript object
   let cookies: object = document.cookie
-  .split(';')
-  .map(cookie => cookie.split('='))
-  .reduce((accumulator, [key, value]) => ({ ...accumulator, [key.trim()]: decodeURIComponent(value) }), {});
+    .split(';')
+    .map(cookie => cookie.split('='))
+    .reduce((accumulator, [key, value]) => ({ ...accumulator, [key.trim()]: decodeURIComponent(value) }), {});
 
   //if user isn't logged in, HTstatus cookie won't exist
   let userAuthStatus: string = cookies.HTstatus || 'not logged in';
 
-  let postResponseStatusCode;
+  let postResponseStatusCode: number;
 
   // when true, spinner on submit button animates
-  let loading = false;
+  let loading: boolean = false;
   // when true, hides the element (in this case, the form)
-  let hidden = false;
+  let hidden: boolean = false;
   // when true, shows the success/failure alert message
-  let submitted = false;
+  let submitted: boolean = false;
 
-  const postForm = async () => {
+  const postForm = async (): Promise<any> => {
     //shoelace serializer for turning FormData into JSON
     const form = document.querySelector('form')
     const data = serialize(form)
 
-    const response = await fetch('http://localhost:5000/api', {
+    return fetch('http://localhost:5000/api', {
         method: 'POST', 
           body: JSON.stringify(data),
           headers: {
@@ -42,20 +42,20 @@
               'Accept': 'application/json'
           }
     })
-        
-    // did something go wrong with the fetch?
-    // if yes, the function stops here
-    if (!response.ok) {
-      postResponseStatusCode = response.status; 
-      throw new Error(`status: ${response.status}`);
+      .then(response => {
+
+        // did something go wrong with the fetch?
+        // if yes, the function stops here
+        if (!response.ok) {
+          postResponseStatusCode = response.status;
+          throw new Error(`status: ${response.status}`);
+        }
+
+        // otherwise, return jira response promise
+        postResponseStatusCode = response.status;
+        return response.json();
+      })
     }
-
-    // otherwise, return the jira response json data
-    const json = await response.json()
-    postResponseStatusCode = response.status;
-
-    return json;
-  }
 
   // handles front-end reaction to form submission
   const onSubmit = () => {
@@ -64,7 +64,6 @@
 
       // do the post fetch function
       postForm()
-      
       // if no error, hide form and log new issue ID
       .then(jiraResponseData => {
         loading = false;

--- a/src/lib/FeedbackForm.svelte
+++ b/src/lib/FeedbackForm.svelte
@@ -22,8 +22,6 @@
 
   let postResponseStatusCode;
 
-  
-
   // when true, spinner on submit button animates
   let loading = false;
   // when true, hides the element (in this case, the form)

--- a/src/lib/FeedbackForm.svelte
+++ b/src/lib/FeedbackForm.svelte
@@ -17,18 +17,15 @@
   .map(cookie => cookie.split('='))
   .reduce((accumulator, [key, value]) => ({ ...accumulator, [key.trim()]: decodeURIComponent(value) }), {});
 
-  //if user ins't logged in, HTstatus cookie won't exist
+  //if user isn't logged in, HTstatus cookie won't exist
   let userAuthStatus: string = cookies.HTstatus || 'not logged in';
 
   let postResponseStatusCode;
 
   let loading = false;
   
-  // const isUserLoggedIn = async () => {
-  //   const res = await fetch('/cgi/ping');
-  //   const broken = res.json()
-  //   console.log(broken)
-  // }
+  // TODO
+  // add try/catch to fetch
   const onSubmit = async () => {
     loading = true;
     //shoelace serializer for turning FormData into JSON
@@ -44,11 +41,20 @@
             }
         })
 
-        const json = await res.json()
-        postResponseStatusCode = res.status;
+    const json = await res.json()
+    postResponseStatusCode = res.status;
+
+    if (res.ok) {
+
+        
         loading = false;
         console.log(`request created in service desk ${json.serviceDeskId}: ${json.issueKey}`)
         console.log('status code', postResponseStatusCode)
+    } else {
+      loading = false;
+      throw new Error(`There was an error posting the form: ${res.status}, ${res.statusText}`)
+    }
+     
     }
 </script>
 
@@ -78,6 +84,7 @@
 
       
       <!-- <FormMessage /> -->
+    
       <section>
         {#if postResponseStatusCode === 200}
         <div transition:slide>
@@ -85,6 +92,14 @@
             <sl-icon slot="icon" name="check2-circle"></sl-icon>
             <strong>Thank you!</strong><br />
             Your feedback has been submitted.
+          </sl-alert> 
+        </div>
+        {:else if postResponseStatusCode === 429}
+        <div transition:slide>
+          <sl-alert variant="danger" open>
+            <sl-icon slot="icon" name="exclamation-octagon"></sl-icon>
+            <strong>Limit reached</strong><br />
+            You have reached the maximum amount of submissions for this time period. Please submit your request again another time.
           </sl-alert> 
         </div>
         {:else if postResponseStatusCode === 500}

--- a/src/lib/FeedbackForm.svelte
+++ b/src/lib/FeedbackForm.svelte
@@ -11,6 +11,15 @@
   let userURL: string = location.href;
   let userAgent: string = navigator.userAgent;
 
+  //takes long string output of document.cookie and splits it into a usable javascript object
+  let cookies: object = document.cookie
+  .split(';')
+  .map(cookie => cookie.split('='))
+  .reduce((accumulator, [key, value]) => ({ ...accumulator, [key.trim()]: decodeURIComponent(value) }), {});
+
+  //if user ins't logged in, HTstatus cookie won't exist
+  let userAuthStatus: string = cookies.HTstatus || 'not logged in';
+
   let postResponseStatusCode;
 
   let loading = false;
@@ -60,6 +69,7 @@
    
       <input name="userURL" id="userURL" type="hidden" bind:value="{userURL}" />
       <input name="userAgent" id="userAgent" type="hidden" bind:value="{userAgent}" />
+      <input name="userAuthStatus" id="userAuthStatus" type="hidden" bind:value="{userAuthStatus}" />
     
       <div class="form-options">
       <sl-button class="btn form-button" variant="default" type="submit" value="Submit" aria-label="Submit">Cancel</sl-button>

--- a/src/lib/FormMessage.svelte
+++ b/src/lib/FormMessage.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+
+  import '@shoelace-style/shoelace/dist/components/alert/alert.js';
+   
+  
+</script>
+
+<section>
+  <sl-alert variant="success" open>
+    <sl-icon slot="icon" name="check2-circle"></sl-icon>
+    <strong>Thank you!</strong><br />
+    Your feedback has been submitted.
+  </sl-alert>
+</section>
+
+  <style>
+    
+  
+  
+  </style>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,7 +1,15 @@
-import { defineConfig } from 'vite'
-import { svelte } from '@sveltejs/vite-plugin-svelte'
+import { defineConfig } from "vite";
+import { svelte } from "@sveltejs/vite-plugin-svelte";
 
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [svelte()],
-})
+  server: {
+    proxy: {
+      "^/cgi/ping": {
+        target: "https://babel.hathitrust.org",
+        changeOrigin: true,
+      },
+    },
+  },
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,12 +4,4 @@ import { svelte } from "@sveltejs/vite-plugin-svelte";
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [svelte()],
-  server: {
-    proxy: {
-      "^/cgi/ping": {
-        target: "https://babel.hathitrust.org",
-        changeOrigin: true,
-      },
-    },
-  },
 });


### PR DESCRIPTION
TODOs from the code review notes:

- failure state for when API request fails 
- failure state for when too many requests have been made 

I added a `try...catch` block to the `fetch` request so I could catch and throw errors based on failure to fetch. I also added a front-end error message for when a user hits the rate limit (5 submissions within 10 minutes).

The hidden auth field and cookie handling is also in this PR, but should go with [DEV-591](https://hathitrust.atlassian.net/browse/DEV-591). 

Other stuff in here for form submission behavior and different user messages based on success/failure.